### PR TITLE
TimeOut for commands added

### DIFF
--- a/firmware/Serial 7-Segment Display/Serial_7_Segment_Display_Firmware/settings.h
+++ b/firmware/Serial 7-Segment Display/Serial_7_Segment_Display_Firmware/settings.h
@@ -31,6 +31,8 @@
 #define MODE_ANALOG  1
 #define MODE_COUNTER 2
 
+#define CMD_TIMEOUT   50 // !!!NEW
+
 const int TWI_ADDRESS_DEFAULT = 0x71;
 const int BAUD_DEFAULT  = BAUD_9600;  // 9600 for 8MHz, 2x speed
 const int BRIGHTNESS_DEFAULT = 100;  // 100%, full brightness


### PR DESCRIPTION
Hi,

I found out that when I'm trying to send brightness value of 118 the display is cleared. after I looked on your code I found out the reason - 118 is 0x76, the command to clear the display. you are checking the clear display command before commands modes values.

I have solved it by adding a static variable to the function in order to store the time of the command started, and let the user a 50 MS timeOut to send any value, before sending 118/0x76 will clear the display again. 

I opened the software in notepad++, so unfortunately the spacing changed and git diff failed to show the differences. In the file Serial_7_Segment_Display_Firmware.ino the lines that have changed are:
236-237,249,306

I complied it and it complied fine, but didn't flash it. so you may want to check it out before.