### PR TITLE
updates firmware to support SegSev 3.7.0

### DIFF
--- a/firmware/Serial 7-Segment Display/Serial_7_Segment_Display_Firmware/Serial_7_Segment_Display_Firmware.ino
+++ b/firmware/Serial 7-Segment Display/Serial_7_Segment_Display_Firmware/Serial_7_Segment_Display_Firmware.ino
@@ -111,7 +111,8 @@ void displayData()
   while(deviceMode == MODE_DATA)
   {
     //Just hang out and update the display as new data comes in
-    myDisplay.DisplayString(display.digits, display.decimals); //(numberToDisplay, decimal point location)
+    myDisplay.setNumber(display.digits, display.decimals); //(numberToDisplay, decimal point location)
+    myDisplay.refreshDisplay();
 
     serialEvent(); //Check the serial buffer for new data
   }
@@ -138,7 +139,8 @@ void displayCounter()
     if(digitalRead(counterIncrement) == LOW)
     {
       delay(1); //Check the pin 1 ms later - this is for debounce
-      myDisplay.DisplayString(display.digits, 0); //Update display so that it doesn't blink
+      myDisplay.setNumber(display.digits, 0); //Update display so that it doesn't blink
+      myDisplay.refreshDisplay();
 
       if(digitalRead(counterIncrement) == LOW)
       {
@@ -159,8 +161,9 @@ void displayCounter()
     if(digitalRead(counterDecrement) == LOW)
     {
       delay(1); //Check the pin 1 ms later - this is for debounce
-      myDisplay.DisplayString(display.digits, 0); //Update display so that it doesn't blink
-      
+      myDisplay.setNumber(display.digits, 0); //Update display so that it doesn't blink
+      myDisplay.refreshDisplay();
+
       if(digitalRead(counterDecrement) == LOW)
       {
         if(decrementCounted == false) //Only increment counter if this is a new pulse 
@@ -188,7 +191,8 @@ void displayCounter()
     // tempCounter /= 10; //Shave number down by one digit
     // }
 
-    myDisplay.DisplayString(display.digits, 0); //(numberToDisplay, no decimals during counter mode)
+    myDisplay.setNumber(display.digits, 0); //(numberToDisplay, no decimals during counter mode)
+    myDisplay.refreshDisplay();
 
     serialEvent(); //Check the serial buffer for new data
   }  
@@ -220,7 +224,8 @@ void displayAnalog()
     display.digits[3] = voltage7 % 10;
 
     display.decimals = ((1<<DECIMAL1) | (1<<DECIMAL3)); //Turn on the decimals next to digit1 and digit3
-    myDisplay.DisplayString(display.digits, display.decimals); //(numberToDisplay, decimal point location)
+    myDisplay.setNumber(display.digits, display.decimals); //(numberToDisplay, decimal point location)
+    myDisplay.refreshDisplay();
 
     serialEvent(); //Check the serial buffer for new data
   }  
@@ -260,7 +265,7 @@ void updateBufferData()
       break;
     case BRIGHTNESS_CMD:  // Brightness setting mode
       EEPROM.write(BRIGHTNESS_ADDRESS, c);    // write the new value to EEPROM
-      myDisplay.SetBrightness(c); //Set the display to this brightness level
+      myDisplay.setBrightness(c); //Set the display to this brightness level
       break;
     case BAUD_CMD:  // Baud setting mode 
       EEPROM.write(BAUD_ADDRESS, c);  // Update EEPROM with new baud setting

--- a/firmware/Serial 7-Segment Display/Serial_7_Segment_Display_Firmware/System_Functions.ino
+++ b/firmware/Serial 7-Segment Display/Serial_7_Segment_Display_Firmware/System_Functions.ino
@@ -91,7 +91,7 @@ void setupDisplay()
     settingBrightness = BRIGHTNESS_DEFAULT; //By default, unit will be brightest
     EEPROM.write(BRIGHTNESS_ADDRESS, settingBrightness);
   }
-  myDisplay.SetBrightness(settingBrightness); //Set the display to 100% bright
+  myDisplay.setBrightness(settingBrightness); //Set the display to 100% bright
 
   // Set the initial state of displays and decimals 'x' =  off
   display.digits[0] = 'x';
@@ -132,11 +132,31 @@ void setupDisplay()
   //This is the same as a common anode setup.
   int displayType = COMMON_ANODE; 
 
+  // Configure SegSev parameters for this layout
+  uint8_t digitPins[] = {
+    digit1,
+    digit2,
+    digit3,
+    digit4
+  };
+  uint8_t segmentPins[] = {
+    segA,
+    segB,
+    segC,
+    segD,
+    segE,
+    segF,
+    segG,
+    segDP
+  };
+  bool resistorsOnSegments = false;   // 'false' means resistors are on digit pins
+  bool updateWithDelays = false;      // Default 'false' is Recommended
+  bool leadingZeros = false;          // Use 'true' if you'd like to keep the leading zeros
+  bool disableDecPoint = false;       // Use 'true' if your decimal point doesn't exist or isn't connected
+
   //Initialize the SevSeg library with all the pins needed for this type of display
-  myDisplay.Begin(displayType, numberOfDigits, 
-  digit1, digit2, digit3, digit4, 
-  segA, segB, segC, segD, segE, segF, segG, 
-  segDP);
+  myDisplay.begin(displayType, numberOfDigits, digitPins, segmentPins, resistorsOnSegments,
+  updateWithDelays, leadingZeros, disableDecPoint);
 
 #endif
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -168,13 +188,35 @@ void setupDisplay()
 
   int displayType = COMMON_ANODE; //SparkFun 10mm height displays are common anode
 
+  // Configure SegSev parameters for this layout
+  uint8_t digitPins[] = {
+    digit1,
+    digit2,
+    digit3,
+    digit4,
+    digitColon,
+    digitApostrophe
+  };
+  uint8_t segmentPins[] = {
+    segA,
+    segB,
+    segC,
+    segD,
+    segE,
+    segF,
+    segG,
+    segDP,
+    segmentColon,
+    segmentApostrophe
+  };
+  bool resistorsOnSegments = false;   // 'false' means resistors are on digit pins
+  bool updateWithDelays = false;      // Default 'false' is Recommended
+  bool leadingZeros = false;          // Use 'true' if you'd like to keep the leading zeros
+  bool disableDecPoint = false;       // Use 'true' if your decimal point doesn't exist or isn't connected
+
   //Initialize the SevSeg library with all the pins needed for this type of display
-  myDisplay.Begin(displayType, numberOfDigits, 
-  digit1, digit2, digit3, digit4, 
-  digitColon, digitApostrophe, 
-  segA, segB, segC, segD, segE, segF, segG, 
-  segDP,
-  segmentColon, segmentApostrophe);
+  myDisplay.begin(displayType, numberOfDigits, digitPins, segmentPins, resistorsOnSegments,
+  updateWithDelays, leadingZeros, disableDecPoint);
 #endif
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
   
@@ -200,11 +242,31 @@ void setupDisplay()
 
   int displayType = COMMON_CATHODE; 
 
+  // Configure SegSev parameters for this layout
+  uint8_t digitPins[] = {
+    digit1,
+    digit2,
+    digit3,
+    digit4
+  };
+  uint8_t segmentPins[] = {
+    segA,
+    segB,
+    segC,
+    segD,
+    segE,
+    segF,
+    segG,
+    segDP
+  };
+  bool resistorsOnSegments = false;   // 'false' means resistors are on digit pins
+  bool updateWithDelays = false;      // Default 'false' is Recommended
+  bool leadingZeros = false;          // Use 'true' if you'd like to keep the leading zeros
+  bool disableDecPoint = false;       // Use 'true' if your decimal point doesn't exist or isn't connected
+
   //Initialize the SevSeg library with all the pins needed for this type of display
-  myDisplay.Begin(displayType, numberOfDigits, 
-  digit1, digit2, digit3, digit4, 
-  segA, segB, segC, segD, segE, segF, segG, 
-  segDP);
+  myDisplay.begin(displayType, numberOfDigits, digitPins, segmentPins, resistorsOnSegments,
+  updateWithDelays, leadingZeros, disableDecPoint);
 #endif
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 }
@@ -360,7 +422,7 @@ void checkEmergencyReset(void)
   //Quick pin check
   if(digitalRead(0) == HIGH) return;
 
-  myDisplay.SetBrightness(100); //Set display to 100% brightness during emergency reset so we can see it
+  myDisplay.setBrightness(100); //Set display to 100% brightness during emergency reset so we can see it
 
   //Wait 2 seconds, displaying reset-ish things while we wait
   for(uint8_t i = 0 ; i < 10 ; i++)
@@ -392,7 +454,7 @@ void constantDisplay (char *theString, long amountOfTime)
 {
   long startTime = millis();
   while( (millis() - startTime) < amountOfTime)
-    myDisplay.DisplayString(theString, 0); //(numberToDisplay, decimal point location)
+    myDisplay.setNumber(theString, 0); //(numberToDisplay, decimal point location)
 }
 
 // In case of emergency, resets all the system settings to safe values
@@ -404,7 +466,7 @@ void setDefaultSettings(void)
 
   //Reset system brightness to the brightest level
   EEPROM.write(BRIGHTNESS_ADDRESS, BRIGHTNESS_DEFAULT);
-  myDisplay.SetBrightness(BRIGHTNESS_DEFAULT);
+  myDisplay.setBrightness(BRIGHTNESS_DEFAULT);
 
   //Reset the I2C address to the default 0x71
   EEPROM.write(TWI_ADDRESS_ADDRESS, TWI_ADDRESS_DEFAULT);


### PR DESCRIPTION
This existing firmware is designed to be used with a separately maintained fork of [SegSev](https://github.com/sparkfun/SevSeg) and the APIs are now incompatible. It appears at some point after you all created this firmware and the SegSev fork that Dean resumed development on it and gave it a proper license. See the [SegSev repo](https://github.com/DeanIsMe/SevSeg). These updates address the issue by updating various calls to use the newer API.

This change is probably useful for others since folks using library managers will likely end up with the other version. I already had `SegSev` installed for some other projects and when I needed to customize the Serial7SegmentDisplay firmware I ran into compatibility issues. I think this is what another person mentioned in issue #24 

Note that this has only been tested on the S7S board layout. Open segment and 7 segment shield were updated but are untested (since I don't have them :eyes: ).

A summary of the updates are as follows:
- adjusted all existing API calls to lowercase format
- updates all calls matching the signature `DisplayString(digits, decimals);` to the SegSev method `setNumber(digits, decimals)`
- updates all `begin` calls to be compatible with new signature: `begin(uint8_t hardwareConfig, uint8_t numDigitsIn, const uint8_t digitPinsIn[],
                   const uint8_t segmentPinsIn[], bool resOnSegmentsIn,
                   bool updateWithDelaysIn, bool leadingZerosIn, bool disableDecPoint)`
- Calls `refreshDisplay()` as appropriate (See [Readme](https://github.com/DeanIsMe/SevSeg/tree/master?tab=readme-ov-file#refreshing-the-display))

Feel free to close this or test and incorporate at your discretion.  If you don't want to incorporate this, I can continue to use my fork for my own projects that need custom firmware.

Thanks for providing all of this code to support your products. It is all really great :confetti_ball: 